### PR TITLE
feat + doc: Added get_word_of_the_day func and extra documentation

### DIFF
--- a/backend/main_page/views/word_search_view.py
+++ b/backend/main_page/views/word_search_view.py
@@ -14,14 +14,21 @@ class WordSearch(View):
         Function returning word of the day or the searched word verified by api
         :param request: Request
         :return: Response with data: dict and status: status
+        Response(
+            {
+                "word_search": "word" if word exists else "Not found"
+            },
+            status_code: int = 200 if word exists else 400
+        )
         """
         word_searched = request.query_params.get("search", None)
+        user = request.query_params.get("user", None)
 
         if word_searched is not None:
             response = requests.get(API_DICTIONARY + word_searched).json()
             if len(response) == 3:
                 return Response({"word_searched": response["title"]}, status=status.HTTP_404_NOT_FOUND)
-            SearchHistory.objects.create(user=None, search_query=word_searched)
+            SearchHistory.objects.create(user=user, search_query=word_searched)
         else:
             word_searched = self.get_word_of_the_day()
 
@@ -30,7 +37,7 @@ class WordSearch(View):
     @staticmethod
     def get_word_of_the_day() -> str:
         """
-        Fetches from database the most searched word from a week ago, and returns it, else cookie (^*^)
+        Fetches from database the most searched word from a week ago and returns it
         :return: str
         """
-        return "cookie"  # TODO implement word of the day
+        return SearchHistory.objects.latest('search_query').search_query


### PR DESCRIPTION
## Now the WordSearch class view can be use by everyone to get:
### 1. The `word of the day` if there is nothing in the search bar, with the `status_code 200`
### 2. The `searched word` if there is something in the search bar, with the `status_code 200`
### 3. `"Not found"` response if the word doesn't exist, with the `status_code 404`
## Usage
```python
word_searched: Response = WordSearch.as_view()(request)

if word_searched.status_code == 404:
    return word_searched

# do whatever you want with word_searched.data
```